### PR TITLE
re-add support for M1/M2 CPUs

### DIFF
--- a/makefile
+++ b/makefile
@@ -160,6 +160,9 @@ endif
 ifeq ($(ucpu),aarch64)
   mycpu = arm64
 endif
+ifeq ($(ucpu),arm64)
+  mycpu = arm64
+endif
 ifeq ($(ucpu),riscv64)
   mycpu = riscv64
 endif


### PR DESCRIPTION
Was lost during csources update as the `makefile.nimf` was never updated.

Avoiding regenerating _all_ csources.